### PR TITLE
Java 24 Updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,13 +16,13 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Pull Request Version Validation
-        uses: ikmdev/maven-pull-request-version-validation-action@v2
+        uses: ikmdev/maven-pull-request-version-validation-action@v2.1.0
         
   build-job:
     name: Build Job
     runs-on: ubuntu-24.04
     steps:      
       - name: Build IKMDEV Code
-        uses: ikmdev/maven-clean-install-build-action@v3
+        uses: ikmdev/maven-clean-install-build-action@v3.5.0
         with:
           branch_name: ${{github.ref_name}}

--- a/.github/workflows/post_build.yaml
+++ b/.github/workflows/post_build.yaml
@@ -27,7 +27,7 @@ jobs:
           
       - name: IKMDEV Post Build Action
         id: ikmdev_post_build
-        uses: ikmdev/maven-post-build-action@v3.1.0
+        uses: ikmdev/maven-post-build-action@v3.2.0
         with:
             nexus_repo_password: ${{secrets.EC2_NEXUS_PASSWORD}}
             branch_name: ${{github.event.workflow_run.head_branch}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           token: ${{secrets.IKMDEVOPS_PAT_TOKEN}}
 
       - name: Shared Release Action
-        uses: ikmdev/maven-semver-release-action@v2
+        uses: ikmdev/maven-semver-release-action@v2.7.0
         with:
           version_type: ${{ github.event.inputs.version_type }}
           github_token: ${{secrets.GITHUB_TOKEN}}

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,0 @@
---enable-preview

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://nexus.tinkarbuild.com/repository/maven-public//org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip
+distributionUrl=https://nexus.tinkarbuild.com/repository/maven-public//org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,15 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
-        <java.version>23</java.version>
+        <maven.compiler.source>24</maven.compiler.source>
+        <maven.compiler.target>24</maven.compiler.target>
+        <java.version>24</java.version>
+
+        <!-- Properties Needed To Build On Java 24 (Start) -->
+        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
+        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
+        <!-- Properties Needed To Build On Java 24 (End) -->
+
         <lucene.version>9.12.1</lucene.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tinkar-core.version>1.118.0</tinkar-core.version>
@@ -93,6 +99,42 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
                 </plugin>
+
+                <!-- Maven Dependency Plugin Fix (Start) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>analyze</id>
+                            <goals>
+                                <goal>analyze-only</goal>
+                            </goals>
+                            <configuration>
+                                <ignoredNonTestScopedDependencies>
+                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
+                                </ignoredNonTestScopedDependencies>
+                                <ignoredUnusedDeclaredDependencies>
+                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
+                                </ignoredUnusedDeclaredDependencies>
+                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+                                <ignoredUsedUndeclaredDependencies>
+                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
+                                </ignoredUsedUndeclaredDependencies>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <dependencies>
+                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
+                        <dependency>
+                            <groupId>org.apache.maven.shared</groupId>
+                            <artifactId>maven-dependency-analyzer</artifactId>
+                            <version>${maven-dependency-analyzer.version}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <!-- Maven Dependency Plugin Fix (End) -->
+
             </plugins>
         </pluginManagement>
     </build>
@@ -262,5 +304,28 @@
                 </plugins>
             </build>
         </profile>
+
+        <!-- codeQuality profile to override pmd configuration from build-parent
+        Need to ovverride aggregate parameter as it is deprecated. -->
+        <profile>
+            <!-- To disable this, use something like "mvn install -P!codeQuality" -->
+            <id>codeQuality</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <configuration>
+                            <aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
+                            <targetJdk>${java.version}</targetJdk>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <log4j.version>3.0.0-alpha1</log4j.version>
         <slf4j.version>2.0.17</slf4j.version>
         <tinkar-composer.version>1.8.0</tinkar-composer.version>
-        <eclipse-collections-api.version>12.0.0.M3-r2</eclipse-collections-api.version>
+        <eclipse-collections-api.version>13.0.0</eclipse-collections-api.version>
         <maven-plugin-plugin.version>3.13.0</maven-plugin-plugin.version>
         <maven-plugin-annotations.version>3.15.0</maven-plugin-annotations.version>
         <maven-plugin-api.version>3.9.9</maven-plugin-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
         <lucene.version>9.12.1</lucene.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <tinkar-core.version>1.121.0</tinkar-core.version>
+        <tinkar-core.version>1.122.0</tinkar-core.version>
         <tinkar-schema.version>1.42.0</tinkar-schema.version>
         <tinkar-transformer-api.version>1.7.0</tinkar-transformer-api.version>
         <log4j.version>3.0.0-alpha1</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
         <groupId>dev.ikm.build</groupId>
         <artifactId>java-parent</artifactId>
         <version>1.64.0</version>
-        <relativePath/>
     </parent>
 
     <groupId>dev.ikm.tinkar</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dev.ikm.build</groupId>
         <artifactId>java-parent</artifactId>
-        <version>1.63.0</version>
+        <version>1.64.0</version>
         <relativePath/>
     </parent>
 
@@ -49,14 +49,9 @@
     </scm>
 
     <properties>
-        <maven.compiler.source>24</maven.compiler.source>
-        <maven.compiler.target>24</maven.compiler.target>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <java.version>24</java.version>
-
-        <!-- Properties Needed To Build On Java 24 (Start) -->
-        <maven-dependency-analyzer.version>1.16.0</maven-dependency-analyzer.version>
-        <maven-pmd-plugin.version>3.27.0</maven-pmd-plugin.version>
-        <!-- Properties Needed To Build On Java 24 (End) -->
 
         <lucene.version>9.12.1</lucene.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -99,42 +94,6 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>${maven-deploy-plugin.version}</version>
                 </plugin>
-
-                <!-- Maven Dependency Plugin Fix (Start) -->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <executions>
-                        <execution>
-                            <id>analyze</id>
-                            <goals>
-                                <goal>analyze-only</goal>
-                            </goals>
-                            <configuration>
-                                <ignoredNonTestScopedDependencies>
-                                    <ignoredNonTestScopedDependency>org.slf4j:*</ignoredNonTestScopedDependency>
-                                </ignoredNonTestScopedDependencies>
-                                <ignoredUnusedDeclaredDependencies>
-                                    <ignoredUnusedDeclaredDependency>org.slf4j:*</ignoredUnusedDeclaredDependency>
-                                </ignoredUnusedDeclaredDependencies>
-                                <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
-                                <ignoredUsedUndeclaredDependencies>
-                                    <ignoredUsedUndeclaredDependency>dev.ikm.jpms:eclipse-collections-api</ignoredUsedUndeclaredDependency>
-                                </ignoredUsedUndeclaredDependencies>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <dependencies>
-                        <!-- Necessary for JDK 24. Should be removed for updates of dependency plugin -->
-                        <dependency>
-                            <groupId>org.apache.maven.shared</groupId>
-                            <artifactId>maven-dependency-analyzer</artifactId>
-                            <version>${maven-dependency-analyzer.version}</version>
-                        </dependency>
-                    </dependencies>
-                </plugin>
-                <!-- Maven Dependency Plugin Fix (End) -->
-
             </plugins>
         </pluginManagement>
     </build>
@@ -304,28 +263,5 @@
                 </plugins>
             </build>
         </profile>
-
-        <!-- codeQuality profile to override pmd configuration from build-parent
-        Need to ovverride aggregate parameter as it is deprecated. -->
-        <profile>
-            <!-- To disable this, use something like "mvn install -P!codeQuality" -->
-            <id>codeQuality</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-pmd-plugin</artifactId>
-                        <configuration>
-                            <aggregate combine.self="override"></aggregate> <!-- Overridden due to deprecation -->
-                            <targetJdk>${java.version}</targetJdk>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
     </profiles>
 </project>


### PR DESCRIPTION
- Updated build-parent to 1.64.0

- Updated the GH Actions to us newer released versions
        - ikmdev/maven-pull-request-version-validation-action@v2.1.0
        - ikmdev/maven-clean-install-build-action@v3.5.0
        - ikmdev/maven-post-build-action@v3.2.0
        - ikmdev/maven-semver-release-action@v2.7.0

- Updated the maven wrapper to 3.9.11

- Removed "--enable-preview" from codebase

- Updated README